### PR TITLE
Setup boilerplate, get tests setup

### DIFF
--- a/src/d3-transform.js
+++ b/src/d3-transform.js
@@ -1,0 +1,11 @@
+(function() {
+  d3.svg.transform = function() {
+    var my = function() {
+      return "";
+    };
+
+    /* XXX: add method-chaining functions to my here */
+
+    return my;
+  };
+})();

--- a/test/d3-transform-test.js
+++ b/test/d3-transform-test.js
@@ -1,18 +1,22 @@
-
 var vows = require('vows'),
     assert = require('assert'),
-    jsdom = require('jsdom'),
-    d3 = require('d3');
-    translate = require("../src/d3-transform.js");
+    jsdom = require('jsdom');
+
+/*
+ * Don't require d3 in a var declaration so the name is available to
+ * d3-transform. This makes it global, which should probably be avoided but
+ * ???
+ */
+d3 = require('d3');
+var transform = require("../src/d3-transform.js");
 
 vows.describe('d3-transform').addBatch({
-  'when transforming a thing': {
-    topic: jsdom.jsdom("<html><head></head><body><svg></svg></body></html>"),
-    "for a simple 2-element translate": {
-      topic: function() { return d3.select("svg").selectAll(".x").data([1,2,3]).enter().append("rect").translate([10,10]) },
-      "we get a thing": function(topic) {
-        assert.equal(topic,1);
-      }
+  'the initial object' : {
+    topic : function() {
+      return d3.svg.transform();
+    },
+    'is an identity transform' : function(topic) {
+      assert.equal(topic(), "");
     }
   }
 }).export(module);


### PR DESCRIPTION
Add the `transform()` function to `d3.svg`, since this is an SVG-specific feature. Nothing but the name has been defined.

Get tests working by requiring d3 as a global variable. This makes it available to the d3-transform module. There may be a better way to do this, but I'm unaware of it.

Tests passing.
