### PR TITLE
typo in example of how bad things are when you don't use d3-transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ d3.select('svg').selectAll('g')
     .data([{ size: 5 }, { size: 10 }])
   .enter().append('g')
     .attr('transform', function(d, i) {
-      return "translate(20," + d.size * 10 + ") rotate (40) scale(" + d.size + "2)");
+      return "translate(20," + d.size * 10 + ") rotate (40) scale(" + ( d.size + 2 ) + ")");
     });
 ```
 


### PR DESCRIPTION
rationale: `5 + "2" = "52"`
