### PR TITLE
seq: add support for sequencing existing transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,21 @@ d3.select('svg.example2').selectAll('g')
     .attr('transform', transform2);
 ```
 
-The result is a document that looks like this:
+Another way to compose multiple transform objects is to use the `seq`
+operation:
+
+```javascript
+var transform1 = d3.svg.transform()
+  .translate(10,20);
+
+var transform2 = d3.svg.transform()
+  .scale(function(d) { return [d.size];})
+
+var transform =
+  transform1.seq(transform2);
+```
+
+With either of these approaches, the result is a document that looks like this:
 
 ```html
 <svg>

--- a/src/d3-transform.js
+++ b/src/d3-transform.js
@@ -7,8 +7,12 @@
       var n = args.length;
 
       transforms.push(function() {
-        return kind + '(' + (n == 1 && typeof args[0] == 'function'
-            ? args[0].apply(this, arr(arguments)) : args) + ')';
+        if (kind == 'seq') {
+          return args.map(function (f) { return f(); }).join(' ')
+        } else {
+          return kind + '(' + (n == 1 && typeof args[0] == 'function'
+              ? args[0].apply(this, arr(arguments)) : args) + ')';
+        }
       });
     };
 
@@ -25,7 +29,7 @@
       }).join(' ');
     };
 
-    ['translate', 'rotate', 'scale', 'matrix', 'skewX', 'skewY'].forEach(function(t) {
+    ['translate', 'rotate', 'scale', 'matrix', 'skewX', 'skewY', 'seq'].forEach(function(t) {
       my[t] = function() {
         push(t, arr(arguments));
         return my;


### PR DESCRIPTION
```javascript
var shift   = d3Transform.translate([x, y]),
    unshift = d3Transform.translate([-x, -y]);

shift.seq(unshift) /* identity (if the floats work out) */
```
I'll change the operation name (`seq` currently) to whatever the consensus name is.

Closes #14